### PR TITLE
Remove hack in map

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const DEFAULTS = {
 }
 
 /* --- Functional Utilities --- */
-const map = fn => x => (x.map ? x.map(fn) : fn(x)) // FIXME remove check
+const map = fn => x => x.map(fn)
 const chain = fn => m => m.chain(fn)
 const join = m => m.join()
 const compose = (...fns) => (res, ...args) =>
@@ -23,6 +23,7 @@ const reduce = fn => zero => xs => xs.reduce(fn, zero)
 
 const split = d => s => s.split(d)
 const int = flip(parseInt)(10)
+const handleArray = a => (Array.isArray(a) ? a : Identity.of(a))
 
 const createRootObj = compose(
   join,
@@ -113,7 +114,9 @@ class Mapper {
         getMappingFilter(mapping, this.config.types),
         ...this.config.preFilters,
         /* Begin user-land transforms */
-        map(field => get(field, this.config.objDelimiter)(curr))
+        m => (Array.isArray(m) ? m : join(m)), // FIXME remove check?,
+        map(field => get(field, this.config.objDelimiter)(curr)),
+        handleArray
       )
 
       return fn(sourceField, mapping, this.config, curr, accum)


### PR DESCRIPTION
Hey @DrBoolean I am going through https://mostly-adequate.gitbooks.io/mostly-adequate-guide/ch12.html#types-n-types (which is incredible by the way) and I am trying to make this library more functional (don't worry, I made this library solely to learn functional programming patterns)

As for the first thing to clean up, I am trying to find a better way to handle this Array vs single value discrepancy. It seems weird that I have to check `Array.isArray` twice. Is there a better way with `traverse/sequence`?

Is there a common FP type that acts like List but has a join method? Why doesn't [`List`](https://mostly-adequate.gitbooks.io/mostly-adequate-guide/appendix_b.html#list) have a `join` method in the first place?